### PR TITLE
Small refactor and improvements

### DIFF
--- a/docs/musescoreCreation.md
+++ b/docs/musescoreCreation.md
@@ -6,12 +6,13 @@ Alternatively, start up Musescore and create a new score. It's pretty simple, ju
 ### Channels
 The script is very strict about the order and quantity of the instruments. Three instruments are required with the drumset being optional.
 If you have a drumset, make sure it's at the bottom.
-I recommend picking channels 1 and 2 as square instruments, those are under the electronic instuments, because those are the first two channels on a Gameboy.
-The next, I recommend as a sine wave or saw wave channel for the third channel.
+While technically any instrument can be used for channels 1-3, it is _strongly_ recommended picking channels 1 and 2 as square instruments
+(under the electronic instuments) as those are the first two channels on a Gameboy.
+For channel 3, a sine wave or saw wave instrument is heavily advised.
 There is only one drumset under percussion for channel 4. It can be omited if you don't need it.
+Using anything other than a drumset will not work or work as expected.
 
 Instruments can be changed at any time in Musescore by pressing `i`.
-
 The template file is set up with the four recommended instruments by default.
 
 ### Writing your score
@@ -26,7 +27,7 @@ Alternatively, notes in a chord can be played sequentially in a channel if the c
 Tuplets are currently unsupported. They can be faked by alternating between lengths every other note.
 For example, ` 1/4 - 1/4 - 1/4` in a triplet could be `1/8 - 1/4 - 1/8`.
 
-Tied notes are supported. However, **any tie lasting longer than a whole note is wholly unsupported**.
+Tied notes are supported. However, **any tie lasting longer than a whole note is wholly unsupported at this time**.
 
 Notes must be no smaller than `1/16`.
 
@@ -49,7 +50,7 @@ Often times this process causes more problems than it's worth. Unless this is th
 
 #### Importing from Finale NotePad (*.mus)
 Some sites only offer downloads for `.mus` files, which can't be directly opened in Musescore. The file has to be opened in Finale NotePad
-and then exported to MusicXML within Finale. This method should also work for the trial version of Finale.
+and then exported to MusicXML within Finale. This method should also work for the trial version of Finale. This has not yet been tested.
 
 ### Saving your MusicXML
 You can save the project in Musescore's format, but I recommend just exporting as MusicXML from the file menu > export.

--- a/docs/runningScript.md
+++ b/docs/runningScript.md
@@ -31,6 +31,12 @@ If you want to manually specify a tempo, use the `--tempo` parameter:
 muse2pokecrystal -i <musicxml> -o <asm> --tempo <bpm>
 ```
 
+If the script fails to detect the song name or you want to export it using a different name,
+use the `--name` parameter:
+```
+muse2pokecrystal -i <musicxml> -o <asm> --name "<Your Song Name>"
+```
+
 This can be run locally in your folder of placed in your binaries.
 It requires Python 3 to run (sorry Python 2 bois).
 

--- a/muse2pokecrystal.py
+++ b/muse2pokecrystal.py
@@ -7,7 +7,7 @@ import sys, getopt
 asmfile = None
 # <part-list><score-part id=""><part-name>Name</partname></score-part></part-list>
 # <part id=""><measure number="1"><notes /></measure></part>
-def process_score(xmlfile, musicfile, nonoise, manualtempo, tempo):
+def process_score(xmlfile, musicfile, nonoise, manualtempo, tempo, song_title, provided_name):
     global asmfile
     asmfile = open(musicfile, "w")
     # (part id, part-name)
@@ -15,11 +15,11 @@ def process_score(xmlfile, musicfile, nonoise, manualtempo, tempo):
 
     ScoreTree = parse(xmlfile)
     xmlroot = ScoreTree.getroot()
-    try:
-    	song_title = xmlroot.find('./work/work-title').text
-    except AttributeError:
-        print("\033[93mCould not guess song name. Using generic name.\033[0m")
-        song_title = "Music Song"
+    if provided_name is False:
+        try:
+            song_title = xmlroot.find('./work/work-title').text
+        except AttributeError:
+            print("\033[93mCould not guess song name. Using generic name.\033[0m")
     pointer_title = song_title.replace(':', '').replace(' ','')
     parts = xmlroot.find('part-list')
     for part in parts.findall('score-part'):
@@ -220,11 +220,13 @@ def parse_channel4(part, title):
 def main(argv):
     infile = ""
     outfile = ""
-    noiseless = False
-    speedoverride = False
     speed = 120
+    speedoverride = False
+    songname = "Music Song"
+    nameoverride = False
+    noiseless = False
     try:
-        opts, args = getopt.getopt(argv,"hi:o:",["score=","code=", "tempo=", "noiseless"])
+        opts, args = getopt.getopt(argv,"hi:o:",["score=","code=", "tempo=", "name=", "noiseless"])
     except getopt.GetoptError:
         print('muse2pokecrystal -i <musicxml> -o <music code>')
         sys.exit(2)
@@ -239,9 +241,12 @@ def main(argv):
         elif opt in ("--tempo"):
             speed = arg
             speedoverride = True
+        elif opt in ("--name"):
+            songname = arg
+            nameoverride = True
         elif opt in ("--noiseless"):
             noiseless = True
-    process_score(infile, outfile, noiseless, speedoverride, speed)
+    process_score(infile, outfile, noiseless, speedoverride, speed, songname, nameoverride)
 
 if __name__=="__main__":
     main(sys.argv[1:])

--- a/muse2pokecrystal.py
+++ b/muse2pokecrystal.py
@@ -101,22 +101,12 @@ def parity_check(musicfile, nonoise):
                 sys.exit(1)
     print("\n\033[94mParity check succeeded!")
 
-def noise_process(pitch):
+def note_process(pitch, channel):
     altered = pitch.find('alter')
-    step = pitch.find('display-step').text
-    if altered is not None: altered = altered.text
-    else: altered = '0'
-    nibble = '_'
-    if int(altered) < 0:
-        nibble = '#'
-        step = chr(ord(step)-1)
-    elif int(altered) > 0: nibble = '#'
-    noted = "{}{}".format(step, nibble)
-    return noted
-
-def note_process(pitch):
-    altered = pitch.find('alter')
-    step = pitch.find('step').text
+    if channel is 4:
+        step = pitch.find('display-step').text
+    else:
+        step = pitch.find('step').text
     if altered is not None: altered = altered.text
     else: altered = '0'
     nibble = '_'
@@ -152,36 +142,23 @@ def note_print(part, channel):
                     dura += int(note.find('duration').text)
                 elif note.find('./tie[@type="start"]') is not None:
                     tied = True
-                    if channel is not 4:
-                        step = note_process(pitch)
-                    else:
-                        step = noise_process(pitch)
+                    step = note_process(pitch, channel)
                     dura = int(note.find('duration').text)
                 elif note.find('./tie[@type="stop"]') is not None:
                     if int(note.find('duration').text) + dura > 16:
                         print("\n\033[91m\033[1mLength check failed!")
                         print("Note too long in Channel {}! Note length {}.\033[0m".format(channel, dura + int(note.find('duration').text)))
                         sys.exit(2)
-                    if channel is not 4:
-                        if step == note_process(pitch):
-                            t = "\tnote {}, {}\n".format(note_process(pitch),int(note.find('duration').text)+dura)
-                        else:
-                            asmfile.write("\tnote {}, {}\n".format(step,dura))
-                            t = "\tnote {}, {}\n".format(note_process(pitch),note.find('duration').text)
+                    if step == note_process(pitch, channel):
+                        t = "\tnote {}, {}\n".format(note_process(pitch, channel),int(note.find('duration').text)+dura)
                     else:
-                        if step == noise_process(pitch):
-                            t = "\tnote {}, {}\n".format(noise_process(pitch),int(note.find('duration').text)+dura)
-                        else:
-                            asmfile.write("\tnote {}, {}\n".format(step,dura))
-                            t = "\tnote {}, {}\n".format(noise_process(pitch),note.find('duration').text)
+                        asmfile.write("\tnote {}, {}\n".format(step,dura))
+                        t = "\tnote {}, {}\n".format(note_process(pitch, channel),note.find('duration').text)
                     tied = False
                     step = ''
                     dura = 0
                 else:
-                    if channel is not 4:
-                        t = "\tnote {}, {}\n".format(note_process(pitch),note.find('duration').text)
-                    else:
-                        t = "\tnote {}, {}\n".format(noise_process(pitch),note.find('duration').text)
+                    t = "\tnote {}, {}\n".format(note_process(pitch, channel),note.find('duration').text)
                 if t != None: asmfile.write(t)
 
 # tempo, volume, dutycycle, tone, vibrato, notetype, octave, stereopanning

--- a/muse2pokecrystal.py
+++ b/muse2pokecrystal.py
@@ -15,7 +15,11 @@ def process_score(xmlfile, musicfile, nonoise, manualtempo, tempo):
 
     ScoreTree = parse(xmlfile)
     xmlroot = ScoreTree.getroot()
-    song_title = xmlroot.find('./work/work-title').text
+    try:
+    	song_title = xmlroot.find('./work/work-title').text
+    except AttributeError:
+        print("\033[93mCould not guess song name. Using generic name.\033[0m")
+        song_title = "Music Song"
     pointer_title = song_title.replace(':', '').replace(' ','')
     parts = xmlroot.find('part-list')
     for part in parts.findall('score-part'):


### PR DESCRIPTION
# Summary of Changes

- Script now auto assigns a song title when it can't detect it and warns the user
- Added the `--name` parameter and updated docs
  - Allows for specifying an undetected name or quickly replacing an existing song
- The `note_process` and `noise_process` were refactored into one function
- The `note_print` function was tweaked
  - Fixed a bug where the script would output two octave changes at the beginning of a channel
if the starting octave was not `4`.
  - Fixed a bug where note ties were not detected on channel 4
  - Refactored so channel 4 also uses `note_print`
  - Note ties are now checked to make sure that they don't exceed length `16`
- Misc doc tweaks